### PR TITLE
Pin at least shelljs@0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chalk": "^2.3.2",
     "diff": "^3.5.0",
     "loglevel": "^1.6.1",
-    "shelljs": "^0.8.1",
+    "shelljs": "^0.8.5",
     "shelljs.exec": "^1.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Because of https://nvd.nist.gov/vuln/detail/CVE-2022-0144

Landing this is going to require a release. 